### PR TITLE
Add YouTube Live stream URLs

### DIFF
--- a/src/components/EventCard/index.jsx
+++ b/src/components/EventCard/index.jsx
@@ -133,7 +133,7 @@ const EventCard = ({ event, hidden, expanded, isExpandable, onExpand, isChild, d
           <>
             <span className="hidden lg:block mx-2">|</span>
             <div>
-              <Link to={location.locationUrl} className="typo-body">
+              <Link to={event.locationUrl} className="typo-body">
                 {event.location}
               </Link>
               <LocationIcon className="inline-block h-6 w-6 ml-2" />

--- a/src/components/EventCard/index.jsx
+++ b/src/components/EventCard/index.jsx
@@ -144,8 +144,8 @@ const EventCard = ({ event, hidden, expanded, isExpandable, onExpand, isChild, d
           <>
             <span className="hidden lg:block mx-2">|</span>
             <span>
-              <Link to="https://www.youtube.com/c/nextflow" className="typo-body text-gray-600">
-                Watch on youtube
+              <Link to={event.youtubeUrl} className="typo-body text-gray-600">
+                {event.youtube}
               </Link>
               <YoutubeRectangleIcon className="inline-block h-6 w-6 ml-2 text-gray-600" />
             </span>

--- a/src/components/EventCard/index.jsx
+++ b/src/components/EventCard/index.jsx
@@ -133,8 +133,8 @@ const EventCard = ({ event, hidden, expanded, isExpandable, onExpand, isChild, d
           <>
             <span className="hidden lg:block mx-2">|</span>
             <div>
-              <Link to="https://goo.gl/maps/K3chvdYLa9BfDpaD9" className="typo-body">
-                Torre Glòries, Avinguda Diagonal, 211, 08018 Barcelona, Spain
+              <Link to={location.locationUrl} className="typo-body">
+                {event.location}
               </Link>
               <LocationIcon className="inline-block h-6 w-6 ml-2" />
             </div>

--- a/src/content/events/oct-12-automated-production-engine-to-decode-the-tree-of-life/index.md
+++ b/src/content/events/oct-12-automated-production-engine-to-decode-the-tree-of-life/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/YUZVtPkIgqM
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-12-designing-mechanisms-into-bactopia-to-support-its-users-and-contribute-back-to-the-community/index.md
+++ b/src/content/events/oct-12-designing-mechanisms-into-bactopia-to-support-its-users-and-contribute-back-to-the-community/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/YUZVtPkIgqM
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-12-nf-core-community-updates/index.md
+++ b/src/content/events/oct-12-nf-core-community-updates/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/YUZVtPkIgqM
 ---
 
 The nf-core community collaborates to build a curated set of analysis pipelines built using Nextflow.

--- a/src/content/events/oct-12-summit-social/index.md
+++ b/src/content/events/oct-12-summit-social/index.md
@@ -1,7 +1,7 @@
 ---
 timeframe: 7:00 - 8:30 PM (90 min)
 title: Summit social
-description: Drinks, cocktails and networking,
+description: Join us for drinks, cocktails and networking.
 datetime: 2022-10-12T19:00:00.000Z
 date: Oct 12, 2022
 time: 7:00 PM

--- a/src/content/events/oct-12-summit-social/index.md
+++ b/src/content/events/oct-12-summit-social/index.md
@@ -7,4 +7,6 @@ date: Oct 12, 2022
 time: 7:00 PM
 tags:
   - Social
+location: Torre Glòries, Avinguda Diagonal, 211, 08018 Barcelona, Spain
+locationUrl: https://goo.gl/maps/K3chvdYLa9BfDpaD9
 ---

--- a/src/content/events/oct-12-summit-welcome/index.md
+++ b/src/content/events/oct-12-summit-welcome/index.md
@@ -12,5 +12,5 @@ tags:
   - Community
 hasPage: true
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/YUZVtPkIgqM
 ---

--- a/src/content/events/oct-12-talks/index.md
+++ b/src/content/events/oct-12-talks/index.md
@@ -19,4 +19,6 @@ speakers:
 tags:
   - Community
   - Ecosystem
+youtube: Watch on Youtube
+youtubeUrl: https://youtu.be/YUZVtPkIgqM
 ---

--- a/src/content/events/oct-12-using-cloud-can-speed-up-your-time-to-science/index.md
+++ b/src/content/events/oct-12-using-cloud-can-speed-up-your-time-to-science/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/YUZVtPkIgqM
 ---
 
 In IT (and especially in research IT) we have a pantheon of metrics that we use daily, weekly, and monthly to assess the performance of our large-scale compute systems. CPU utilization, memory bandwidth per core, Lustre filesystem throughput - all the way down to cents per core-hour and data center PUE (which boils down to a measure of the thermodynamic efficiency of heat pumps). But there’s a dog not barking: how do we focus on scientist productivity, rather than machine efficiency?

--- a/src/content/events/oct-13-bringing-gxp-compliance-to-nextflow-workflows/index.md
+++ b/src/content/events/oct-13-bringing-gxp-compliance-to-nextflow-workflows/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/Tqw9r2B6bWk
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-deep-dive-into-nextflow-on-azure/index.md
+++ b/src/content/events/oct-13-deep-dive-into-nextflow-on-azure/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/Tqw9r2B6bWk
 ---
 <div className="mb-4">
   <small className="typo-small">
@@ -22,8 +22,8 @@ youtubeUrl: https://www.youtube.com/c/nextflow
 
 <hr className="border-t border-gray-50 mb-4 opacity-20" />
 
-Bioinformatic pipelines are compute intensive. Pipelines are made up of multiple different interdependent tasks. Using the power of Azure, we can dynamically assign the right type and amount of compute for the task, scaling up and down as needed.  
+Bioinformatic pipelines are compute intensive. Pipelines are made up of multiple different interdependent tasks. Using the power of Azure, we can dynamically assign the right type and amount of compute for the task, scaling up and down as needed.
 
-This talk will walk you through how to setup Azure infrastructure and Nextflow to run genomics analysis pipelines in the cloud. You will learn how to create Azure Batch Compute Environments. Using these resources, you will build architecture that runs Nextflow entirely on Azure. We will discuss how to optimize your pipeline configuration to be cost andtime efficient, by providing benchmarking of some common community pipelines. You will also learn how Microsoft is integrating Nextflow into its Genomics on Azure ecosystem that supports secure, optimized, and scalable research on an extensible platform.   
+This talk will walk you through how to setup Azure infrastructure and Nextflow to run genomics analysis pipelines in the cloud. You will learn how to create Azure Batch Compute Environments. Using these resources, you will build architecture that runs Nextflow entirely on Azure. We will discuss how to optimize your pipeline configuration to be cost andtime efficient, by providing benchmarking of some common community pipelines. You will also learn how Microsoft is integrating Nextflow into its Genomics on Azure ecosystem that supports secure, optimized, and scalable research on an extensible platform.
 
 By the end of the session, you will have the resources you need to build a genomics workflow environment with Nextflow on Azure.

--- a/src/content/events/oct-13-epi2me-labs-and-democratising-nanopore-sequence-analysis/index.md
+++ b/src/content/events/oct-13-epi2me-labs-and-democratising-nanopore-sequence-analysis/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
 ---
 Oxford Nanopore Technologies develops and sells DNA and RNA sequencing products. The technology is based on sensing changes in current flow as nucleic acid molecules transit a biological nanopore. Our goal is to enable the analysis of anything, by anyone, anywhere. Our MinION sequencing device is small and portable; it is commonly used in combination with Windows laptops. This presentation will introduce how we are simplifying the DNA sequence analysis processes for non- bioinformaticians who may also be sequencing in the field.
 

--- a/src/content/events/oct-13-from-sharing-our-journeys-to-empowering-the-community-nextflow-and-beyond/index.md
+++ b/src/content/events/oct-13-from-sharing-our-journeys-to-empowering-the-community-nextflow-and-beyond/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
 ---
 The goal of this panel conversation is to bring together our nextflow community to learn from a diverse set of panelists who will share their stories, struggles and successes. The aims of this conversation are to highlight the general gaps that are ubiquitous across the programming and technical communities, the importance of bringing women and students from underrepresented communities together, and ways to share our knowledge beyond our workplaces. The session will be interactive and will conclude with audience Q&A and discussion.

--- a/src/content/events/oct-13-keynote/index.md
+++ b/src/content/events/oct-13-keynote/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Keynote
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 Abstract coming soon!

--- a/src/content/events/oct-13-large-scale-image-processing-with-nextflow/index.md
+++ b/src/content/events/oct-13-large-scale-image-processing-with-nextflow/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-new-pipeline-resources-for-reproducible-analysis/index.md
+++ b/src/content/events/oct-13-new-pipeline-resources-for-reproducible-analysis/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/p70HZ5eFhks
 ---
 Computational pipelines have become one of the most central methodological components of modern biology. Their capacity to support reproducible scientific analysis defines the very foundation of contemporary science. In this talk, I will introduce a new paper collection dedicated to computational pipelines. This collection will appear in the journal  NAR Bioinformatics and Genomics (NAR GAB). NAR GAB is a sister title of Nucleic Acids Research with a special focus on methods and reproducibility in computational biology. The pipeline collection will be open to all platforms and all technologies. Submissions will be reviewed under the same scrutiny as any other type of scientific contribution. One of its objectives will be to engage various communities such as FAANG – the animal genomics community – or GA4GH and encourage large-scale interoperability between pipelines, reference datasets, and benchmark methods.

--- a/src/content/events/oct-13-nextflow-and-the-future-of-containers/index.md
+++ b/src/content/events/oct-13-nextflow-and-the-future-of-containers/index.md
@@ -13,7 +13,7 @@ tags:
   - Nextflow
   - Software
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/p70HZ5eFhks
 ---
 
 Containers have become an essential component in the toolset of scientific workflow developers enabling the deployment of data analysis pipelines at scale in a portable and reproducible manner. However, the increasing complexity and reliance on containers pose new challenges: developers may be required to build several dozen container images and maintain them across different cloud registries. This forces developers to switch the context from the scientific application logic and waste significant amounts of time on “infrastructural” tasks. Moreover, the same software may require container builds depending on CPU architecture, storage environment and custom low-level libraries to run in an efficient manner. Community curated collections such as Biocontainers mitigate this problem, even though they do not provide an ideal answer. This presentation will introduce a novel solution available to Nextflow developers to streamline the provisioning of containers for data analysis pipelines and takes advantage of community standards.

--- a/src/content/events/oct-13-nextflow-quilt-label-query-and-visualize-pipeline-data/index.md
+++ b/src/content/events/oct-13-nextflow-quilt-label-query-and-visualize-pipeline-data/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/cw_WKIB0zRc
 ---
 Quilt is an open platform for storing, labeling, and managing data. Quilt integrates instrument data, metadata, analysis, and visualizations into reusable datasets. Together Nexflow and Quilt provide users with an open platform for reproducible science. Quilt's data versioning and Nextflow's reproducible pipelines allow users to run any version of a pipeline against current and past versions of a dataset, and to trace the lineage of every result.
 

--- a/src/content/events/oct-13-nextflow-tower-in-the-data-analysis-life-cycle/index.md
+++ b/src/content/events/oct-13-nextflow-tower-in-the-data-analysis-life-cycle/index.md
@@ -12,5 +12,5 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/Tqw9r2B6bWk
 ---

--- a/src/content/events/oct-13-nf-core-airrflow-a-pipeline-to-analyze-adaptive-immune-receptor-repertoires-airrs/index.md
+++ b/src/content/events/oct-13-nf-core-airrflow-a-pipeline-to-analyze-adaptive-immune-receptor-repertoires-airrs/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-nf-core-modules-re-usable-unit-tested-dsl2-wrapper-scripts-for-the-nextflow-community/index.md
+++ b/src/content/events/oct-13-nf-core-modules-re-usable-unit-tested-dsl2-wrapper-scripts-for-the-nextflow-community/index.md
@@ -12,10 +12,10 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/cw_WKIB0zRc
 ---
 
-In July 2020, Nextflow provided a syntax extension called DSL2 that permits the re-use of module libraries both within and between pipelines. The new DSL came with the promise of simplifying the implementation and maintenance of data analysis pipelines, especially for the nf-core community which hosts over 50 pipelines that share functionality and core features. 
+In July 2020, Nextflow provided a syntax extension called DSL2 that permits the re-use of module libraries both within and between pipelines. The new DSL came with the promise of simplifying the implementation and maintenance of data analysis pipelines, especially for the nf-core community which hosts over 50 pipelines that share functionality and core features.
 
 We have since created a centralised repository called [nf-core/modules](https://github.com/nf-core/modules) specifically for the purpose of hosting Nextflow DSL2 module files containing tool-specific process definitions and their associated documentation. Each module contribution is reviewed independently and must pass unit tests before merging into the codebase, as well as adhering to a set of best practices in order to make them standardised, re-usable, portable and reproducible. nf-core/modules has now become a reference for [almost 600](https://nf-co.re/modules) standardised wrapper scripts for software tools such as fastqc, bwa, samtools etc. that are re-usable within any Nextflow pipeline.
 

--- a/src/content/events/oct-13-nf-core-rnafusion-implementing-rna-fusion-detection-in-routine-cancer-diagnostics/index.md
+++ b/src/content/events/oct-13-nf-core-rnafusion-implementing-rna-fusion-detection-in-routine-cancer-diagnostics/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-nf-core-sarek-a-workflow-for-germline-tumor-only-and-somatic-analysis-of-ngs-data/index.md
+++ b/src/content/events/oct-13-nf-core-sarek-a-workflow-for-germline-tumor-only-and-somatic-analysis-of-ngs-data/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/cw_WKIB0zRc
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-pipeline-economics-on-cloud/index.md
+++ b/src/content/events/oct-13-pipeline-economics-on-cloud/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 Runaway costs when running your pipelines on Cloud is among the most common concerns of any organisation or research team. In this session we will explore how Cloud Economics work, and discus some common tricks that can help you optimise your running cost on Cloud.

--- a/src/content/events/oct-13-pipeline-parameter-validation-with-the-nf-core-json-schema/index.md
+++ b/src/content/events/oct-13-pipeline-parameter-validation-with-the-nf-core-json-schema/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/p70HZ5eFhks
 ---
 A key feature of Nextflow is its ability to use 'parameters' - configuration variables that can be overwritten at runtime in config files or on the command line. Parameters are a flexible and powerful concept, yet their flexibility can be a problem - developers may need to write a significant amount of code to validate user inputs.
 

--- a/src/content/events/oct-13-price-performance-of-different-cloud-strorage-options-for-nextflow-workflows/index.md
+++ b/src/content/events/oct-13-price-performance-of-different-cloud-strorage-options-for-nextflow-workflows/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/cw_WKIB0zRc
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-summit-dinner/index.md
+++ b/src/content/events/oct-13-summit-dinner/index.md
@@ -7,4 +7,6 @@ tags:
 datetime: 2022-10-13T19:00:00.000Z
 date: Oct 13, 2022
 time: 7:00 PM
+location: Shôko, Passeig Marítim de la Barceloneta, 36, 08005 Barcelona, Spain
+locationUrl: https://g.page/shokobarcelona
 ---

--- a/src/content/events/oct-13-summit-dinner/index.md
+++ b/src/content/events/oct-13-summit-dinner/index.md
@@ -1,7 +1,7 @@
 ---
 timeframe: 7:00 - 10:00 PM (180 min)
 title: Summit dinner
-description: Dinner
+description: The Summit dinner will be held at Shôko, a Restaurant &amp; Lounge Club.
 tags:
   - Social
 datetime: 2022-10-13T19:00:00.000Z

--- a/src/content/events/oct-13-summit-dinner/index.md
+++ b/src/content/events/oct-13-summit-dinner/index.md
@@ -1,7 +1,7 @@
 ---
 timeframe: 7:00 - 10:00 PM (180 min)
 title: Summit dinner
-description: The Summit dinner will be held at Shôko, a Restaurant &amp; Lounge Club.
+description: The Summit dinner will be held at Shôko, a Restaurant and Lounge Club.
 tags:
   - Social
 datetime: 2022-10-13T19:00:00.000Z

--- a/src/content/events/oct-13-talks-1/index.md
+++ b/src/content/events/oct-13-talks-1/index.md
@@ -19,4 +19,6 @@ events:
 datetime: 2022-10-13T10:00:00.000Z
 date: Oct 13, 2022
 time: 10:00 AM
+youtube: Watch on Youtube
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---

--- a/src/content/events/oct-13-talks-2/index.md
+++ b/src/content/events/oct-13-talks-2/index.md
@@ -19,5 +19,5 @@ datetime: 2022-10-13T11:45:00.000Z
 date: Oct 13, 2022
 time: 11:45 AM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/cw_WKIB0zRc
 ---

--- a/src/content/events/oct-13-talks-3/index.md
+++ b/src/content/events/oct-13-talks-3/index.md
@@ -18,5 +18,5 @@ datetime: 2022-10-13T14:15:00.000Z
 date: Oct 13, 2022
 time: 2:15 PM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/p70HZ5eFhks
 ---

--- a/src/content/events/oct-13-talks-4/index.md
+++ b/src/content/events/oct-13-talks-4/index.md
@@ -19,5 +19,5 @@ datetime: 2022-10-13T16:15:00.000Z
 date: Oct 13, 2022
 time: 4:15 PM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
 ---

--- a/src/content/events/oct-13-talks-5/index.md
+++ b/src/content/events/oct-13-talks-5/index.md
@@ -16,5 +16,5 @@ datetime: 2022-10-13T17:45:00.000Z
 date: Oct 13, 2022
 time: 5:45 PM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/Tqw9r2B6bWk
 ---

--- a/src/content/events/oct-13-unlocking-automated-bioinformatics-for-large-scale-healthcare/index.md
+++ b/src/content/events/oct-13-unlocking-automated-bioinformatics-for-large-scale-healthcare/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-a-workflow-to-generate-a-variant-catalogue-from-whole-genome-sequences/index.md
+++ b/src/content/events/oct-14-a-workflow-to-generate-a-variant-catalogue-from-whole-genome-sequences/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-applying-and-deploying-alphafold-at-scale-to-decode-the-human-gut-microbiome-proteome/index.md
+++ b/src/content/events/oct-14-applying-and-deploying-alphafold-at-scale-to-decode-the-human-gut-microbiome-proteome/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-automated-bioinformatics-infrastructure-for-large-scale-sars-cov-2-genomic-surveillance-at-qib/index.md
+++ b/src/content/events/oct-14-automated-bioinformatics-infrastructure-for-large-scale-sars-cov-2-genomic-surveillance-at-qib/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-from-zero-to-nextflow-bringing-nanorate-nanoseq-into-a-workflow/index.md
+++ b/src/content/events/oct-14-from-zero-to-nextflow-bringing-nanorate-nanoseq-into-a-workflow/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-junction-let-investigators-turning-their-data-into-results/index.md
+++ b/src/content/events/oct-14-junction-let-investigators-turning-their-data-into-results/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">
@@ -24,6 +24,6 @@ youtubeUrl: https://www.youtube.com/c/nextflow
 
 jUNCtion is a web application that allows our investigators turn their raw sequencing data into results.
 
-It integrates with our LIMS system and can pull the FASTQ paths into a "Study", allow the investigators to select and run one or more Nextflow workflows on the data, and presents the data back to them via the web. Results can also be shared with other investigators or other campus labs.  
+It integrates with our LIMS system and can pull the FASTQ paths into a "Study", allow the investigators to select and run one or more Nextflow workflows on the data, and presents the data back to them via the web. Results can also be shared with other investigators or other campus labs.
 
 It is written in Java, Javascript, Python, and Bash languages, has a MySQL back-end, queries our LIMS Oracle SQL back-ends, runs under Tomcat, and uses Nextflow as the workflow engine.  Raw data are stored in our cluster's file system, and authentication is integrated with our campus SSO.

--- a/src/content/events/oct-14-nextflow-kubernetes-and-dragens-oh-my/index.md
+++ b/src/content/events/oct-14-nextflow-kubernetes-and-dragens-oh-my/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 Illumina is using Nextflow to orchestrate on-premises clinical applications available with the NovaSeqDX sequencer. We leverage the DRAGEN Bio-IT accelerated computing system within a Kubernetes environment to rapidly execute workflows on sequencing data as it is produced. Nextflow workflows are bundled into "apps" that include workflow parameter definition and automatic UI generation that is seamlessly integrated with sequencing run planning. Apps are currently only available from Illumina, but we ultimately expect to include apps developed by third parties. All components of the system are designed to meet the FDA's IVD (in-vitro diagnostic) standard. This talk will describe the different components of the system and how they interact to rapidly deliver clinical diagnostic reports.

--- a/src/content/events/oct-14-nf-core-hackathon-report/index.md
+++ b/src/content/events/oct-14-nf-core-hackathon-report/index.md
@@ -12,7 +12,7 @@ datetime: 2022-10-14T13:00:00.000Z
 date: Oct 14, 2022
 time: 1:00 PM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---
 
 The nf-core community will run a hackathon in the days leading up to the Nextflow Summit.

--- a/src/content/events/oct-14-options-for-leveling-up-your-nextflow-workflows-on-aws-batch/index.md
+++ b/src/content/events/oct-14-options-for-leveling-up-your-nextflow-workflows-on-aws-batch/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
+++ b/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
@@ -2,13 +2,15 @@
 slug: oct-14-summit-wrap-up-and-farewell
 timeframe: 1:15 - 1:30 PM (15 min)
 title: Summit wrap up and farewell
-tags:
-  - Community
-speakers:
-  - Evan Floden
-isChild: true
-hasPage: true
+description:
 datetime: 2022-10-14T13:15:00.000Z
 date: Oct 14, 2022
 time: 1:15 PM
+speakers:
+  - Evan Floden
+tags:
+  - Community
+hasPage: true
+youtube: Watch on Youtube
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---

--- a/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
+++ b/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
@@ -10,7 +10,6 @@ speakers:
   - Evan Floden
 tags:
   - Community
-hasPage: true
 youtube: Watch on Youtube
 youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---

--- a/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
+++ b/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
@@ -12,5 +12,5 @@ tags:
   - Community
 hasPage: true
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/SouMSDJBE1U
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---

--- a/src/content/events/oct-14-talks-1/index.md
+++ b/src/content/events/oct-14-talks-1/index.md
@@ -19,5 +19,5 @@ datetime: 2022-10-14T10:00:00.000Z
 date: Oct 14, 2022
 time: 10:00 AM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---

--- a/src/content/events/oct-14-talks-2/index.md
+++ b/src/content/events/oct-14-talks-2/index.md
@@ -18,10 +18,9 @@ events:
   - oct-14-automated-bioinformatics-infrastructure-for-large-scale-sars-cov-2-genomic-surveillance-at-qib
   - oct-14-workflow-automation-using-the-aviti-benchtop-sequencing-system-and-nextflow-tower
   - oct-14-nf-core-hackathon-report
-  - oct-14-summit-wrap-up-and-farewell
 datetime: 2022-10-14T11:30:00.000Z
 date: Oct 14, 2022
 time: 11:30 AM
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---

--- a/src/content/events/oct-14-the-spinning-jenny-a-nextflow-pipeline-for-an-agent-based-model-of-the-first-industrial-revolution/index.md
+++ b/src/content/events/oct-14-the-spinning-jenny-a-nextflow-pipeline-for-an-agent-based-model-of-the-first-industrial-revolution/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-workflow-automation-using-the-aviti-benchtop-sequencing-system-and-nextflow-tower/index.md
+++ b/src/content/events/oct-14-workflow-automation-using-the-aviti-benchtop-sequencing-system-and-nextflow-tower/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://www.youtube.com/c/nextflow
+youtubeUrl: https://youtu.be/S9FDUEBSYCg
 ---
 <div className="mb-4">
   <small className="typo-small">
@@ -22,7 +22,7 @@ youtubeUrl: https://www.youtube.com/c/nextflow
 
 <hr className="border-t border-gray-50 mb-4 opacity-20" />
 
-Element Biosciences is passionate about developing new and disruptive solutions in the genomics space.  In March of 2022, we announced the commercial launch of the Element AVITI™ System, a benchtop sequencer with an output of 800M+ read pairs per flow cell and base calling accuracy surpassing 90% Q30 at a 2x150 bp read length.   
+Element Biosciences is passionate about developing new and disruptive solutions in the genomics space.  In March of 2022, we announced the commercial launch of the Element AVITI™ System, a benchtop sequencer with an output of 800M+ read pairs per flow cell and base calling accuracy surpassing 90% Q30 at a 2x150 bp read length.
 
 Sequencing data from AVITI platform can be streamed to the customer’s desired location on AWS, GCP, or a local server while the run is in progress.  After the run is complete, FASTQ files can be generated using the bases2fastq software.
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -241,7 +241,7 @@ const IndexPage = () => {
                   </p>
                   <p className="typo-body flex items-center mb-4">
                     <span className="mr-2">
-                      <Link to="https://www.youtube.com/c/nextflow">
+                      <Link to="https://youtube.com/playlist?list=PLPZ8WHdZGxmUdAJlHowo7zL2pN3x97d32">
                         YouTube
                       </Link>
                     </span>

--- a/src/pages/program/nf-core-hackathon.jsx
+++ b/src/pages/program/nf-core-hackathon.jsx
@@ -21,7 +21,7 @@ const NfCoreHackathonPage = ({ location }) => {
             A week of Nextflow goodness
           </h1>
           <p className="typo-body max-w-2xl mx-auto mb-4">
-            We believe that the Nextflow Summit should be available to everyone, everywhere. That’s why the Nextflow
+            We believe that the Nextflow Summit should be available to everyone, everywhere. That's why the Nextflow
             Summit and nf-core Hackathon will be streamed live and presentations made available after the event.
           </p>
           <p className="typo-body max-w-2xl mx-auto mb-4">

--- a/src/templates/event.jsx
+++ b/src/templates/event.jsx
@@ -100,8 +100,8 @@ const EventPage = ({ data }) => {
               <>
                 <span className="hidden lg:block mx-2">|</span>
                 <span>
-                  <Link to="https://www.youtube.com/c/nextflow" className="typo-body text-gray-600">
-                    Watch on youtube
+                  <Link to={event.youtubeUrl} className="typo-body text-gray-600">
+                    {event.youtube}
                   </Link>
                   <YoutubeRectangleIcon className="inline-block h-6 w-6 ml-2 text-gray-600" />
                 </span>

--- a/src/templates/event.jsx
+++ b/src/templates/event.jsx
@@ -89,8 +89,8 @@ const EventPage = ({ data }) => {
               <>
                 <span className="hidden lg:block mx-2">|</span>
                 <div>
-                  <Link to="https://goo.gl/maps/K3chvdYLa9BfDpaD9" className="typo-body">
-                    Torre Glòries, Avinguda Diagonal, 211, 08018 Barcelona, Spain
+                  <Link to={event.locationUrl} className="typo-body">
+                    {event.location}
                   </Link>
                   <LocationIcon className="inline-block h-6 w-6 ml-2" />
                 </div>


### PR DESCRIPTION
After the event we can chop up these videos to make them individual talks, then update the links again.

For now, each talk points to it's session's live stream video.