### PR TITLE
Remove old YouTube stream links

### DIFF
--- a/src/content/events/oct-13-bringing-gxp-compliance-to-nextflow-workflows/index.md
+++ b/src/content/events/oct-13-bringing-gxp-compliance-to-nextflow-workflows/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/Tqw9r2B6bWk
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-deep-dive-into-nextflow-on-azure/index.md
+++ b/src/content/events/oct-13-deep-dive-into-nextflow-on-azure/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/Tqw9r2B6bWk
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-epi2me-labs-and-democratising-nanopore-sequence-analysis/index.md
+++ b/src/content/events/oct-13-epi2me-labs-and-democratising-nanopore-sequence-analysis/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 Oxford Nanopore Technologies develops and sells DNA and RNA sequencing products. The technology is based on sensing changes in current flow as nucleic acid molecules transit a biological nanopore. Our goal is to enable the analysis of anything, by anyone, anywhere. Our MinION sequencing device is small and portable; it is commonly used in combination with Windows laptops. This presentation will introduce how we are simplifying the DNA sequence analysis processes for non- bioinformaticians who may also be sequencing in the field.
 

--- a/src/content/events/oct-13-from-sharing-our-journeys-to-empowering-the-community-nextflow-and-beyond/index.md
+++ b/src/content/events/oct-13-from-sharing-our-journeys-to-empowering-the-community-nextflow-and-beyond/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 The goal of this panel conversation is to bring together our nextflow community to learn from a diverse set of panelists who will share their stories, struggles and successes. The aims of this conversation are to highlight the general gaps that are ubiquitous across the programming and technical communities, the importance of bringing women and students from underrepresented communities together, and ways to share our knowledge beyond our workplaces. The session will be interactive and will conclude with audience Q&A and discussion.

--- a/src/content/events/oct-13-large-scale-image-processing-with-nextflow/index.md
+++ b/src/content/events/oct-13-large-scale-image-processing-with-nextflow/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-new-pipeline-resources-for-reproducible-analysis/index.md
+++ b/src/content/events/oct-13-new-pipeline-resources-for-reproducible-analysis/index.md
@@ -12,6 +12,6 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/p70HZ5eFhks
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 Computational pipelines have become one of the most central methodological components of modern biology. Their capacity to support reproducible scientific analysis defines the very foundation of contemporary science. In this talk, I will introduce a new paper collection dedicated to computational pipelines. This collection will appear in the journal  NAR Bioinformatics and Genomics (NAR GAB). NAR GAB is a sister title of Nucleic Acids Research with a special focus on methods and reproducibility in computational biology. The pipeline collection will be open to all platforms and all technologies. Submissions will be reviewed under the same scrutiny as any other type of scientific contribution. One of its objectives will be to engage various communities such as FAANG – the animal genomics community – or GA4GH and encourage large-scale interoperability between pipelines, reference datasets, and benchmark methods.

--- a/src/content/events/oct-13-nextflow-and-the-future-of-containers/index.md
+++ b/src/content/events/oct-13-nextflow-and-the-future-of-containers/index.md
@@ -13,7 +13,7 @@ tags:
   - Nextflow
   - Software
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/p70HZ5eFhks
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 
 Containers have become an essential component in the toolset of scientific workflow developers enabling the deployment of data analysis pipelines at scale in a portable and reproducible manner. However, the increasing complexity and reliance on containers pose new challenges: developers may be required to build several dozen container images and maintain them across different cloud registries. This forces developers to switch the context from the scientific application logic and waste significant amounts of time on “infrastructural” tasks. Moreover, the same software may require container builds depending on CPU architecture, storage environment and custom low-level libraries to run in an efficient manner. Community curated collections such as Biocontainers mitigate this problem, even though they do not provide an ideal answer. This presentation will introduce a novel solution available to Nextflow developers to streamline the provisioning of containers for data analysis pipelines and takes advantage of community standards.

--- a/src/content/events/oct-13-nextflow-quilt-label-query-and-visualize-pipeline-data/index.md
+++ b/src/content/events/oct-13-nextflow-quilt-label-query-and-visualize-pipeline-data/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/cw_WKIB0zRc
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 Quilt is an open platform for storing, labeling, and managing data. Quilt integrates instrument data, metadata, analysis, and visualizations into reusable datasets. Together Nexflow and Quilt provide users with an open platform for reproducible science. Quilt's data versioning and Nextflow's reproducible pipelines allow users to run any version of a pipeline against current and past versions of a dataset, and to trace the lineage of every result.
 

--- a/src/content/events/oct-13-nextflow-tower-in-the-data-analysis-life-cycle/index.md
+++ b/src/content/events/oct-13-nextflow-tower-in-the-data-analysis-life-cycle/index.md
@@ -12,5 +12,5 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/Tqw9r2B6bWk
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---

--- a/src/content/events/oct-13-nf-core-modules-re-usable-unit-tested-dsl2-wrapper-scripts-for-the-nextflow-community/index.md
+++ b/src/content/events/oct-13-nf-core-modules-re-usable-unit-tested-dsl2-wrapper-scripts-for-the-nextflow-community/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/cw_WKIB0zRc
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 
 In July 2020, Nextflow provided a syntax extension called DSL2 that permits the re-use of module libraries both within and between pipelines. The new DSL came with the promise of simplifying the implementation and maintenance of data analysis pipelines, especially for the nf-core community which hosts over 50 pipelines that share functionality and core features.

--- a/src/content/events/oct-13-nf-core-sarek-a-workflow-for-germline-tumor-only-and-somatic-analysis-of-ngs-data/index.md
+++ b/src/content/events/oct-13-nf-core-sarek-a-workflow-for-germline-tumor-only-and-somatic-analysis-of-ngs-data/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/cw_WKIB0zRc
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-pipeline-parameter-validation-with-the-nf-core-json-schema/index.md
+++ b/src/content/events/oct-13-pipeline-parameter-validation-with-the-nf-core-json-schema/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/p70HZ5eFhks
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 A key feature of Nextflow is its ability to use 'parameters' - configuration variables that can be overwritten at runtime in config files or on the command line. Parameters are a flexible and powerful concept, yet their flexibility can be a problem - developers may need to write a significant amount of code to validate user inputs.
 

--- a/src/content/events/oct-13-price-performance-of-different-cloud-strorage-options-for-nextflow-workflows/index.md
+++ b/src/content/events/oct-13-price-performance-of-different-cloud-strorage-options-for-nextflow-workflows/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/cw_WKIB0zRc
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-13-talks-2/index.md
+++ b/src/content/events/oct-13-talks-2/index.md
@@ -19,5 +19,5 @@ datetime: 2022-10-13T11:45:00.000Z
 date: Oct 13, 2022
 time: 11:45 AM
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/cw_WKIB0zRc
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---

--- a/src/content/events/oct-13-talks-3/index.md
+++ b/src/content/events/oct-13-talks-3/index.md
@@ -18,5 +18,5 @@ datetime: 2022-10-13T14:15:00.000Z
 date: Oct 13, 2022
 time: 2:15 PM
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/p70HZ5eFhks
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---

--- a/src/content/events/oct-13-talks-4/index.md
+++ b/src/content/events/oct-13-talks-4/index.md
@@ -17,5 +17,5 @@ datetime: 2022-10-13T16:15:00.000Z
 date: Oct 13, 2022
 time: 4:15 PM
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/G3jWR_Tk0Xo
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---

--- a/src/content/events/oct-13-talks-5/index.md
+++ b/src/content/events/oct-13-talks-5/index.md
@@ -16,5 +16,5 @@ datetime: 2022-10-13T17:45:00.000Z
 date: Oct 13, 2022
 time: 5:45 PM
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/Tqw9r2B6bWk
+youtubeUrl: https://youtu.be/ZZODaSfdEH8
 ---

--- a/src/content/events/oct-14-applying-and-deploying-alphafold-at-scale-to-decode-the-human-gut-microbiome-proteome/index.md
+++ b/src/content/events/oct-14-applying-and-deploying-alphafold-at-scale-to-decode-the-human-gut-microbiome-proteome/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-automated-bioinformatics-infrastructure-for-large-scale-sars-cov-2-genomic-surveillance-at-qib/index.md
+++ b/src/content/events/oct-14-automated-bioinformatics-infrastructure-for-large-scale-sars-cov-2-genomic-surveillance-at-qib/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Ecosystem
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-from-zero-to-nextflow-bringing-nanorate-nanoseq-into-a-workflow/index.md
+++ b/src/content/events/oct-14-from-zero-to-nextflow-bringing-nanorate-nanoseq-into-a-workflow/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-nf-core-hackathon-report/index.md
+++ b/src/content/events/oct-14-nf-core-hackathon-report/index.md
@@ -12,7 +12,7 @@ datetime: 2022-10-14T13:00:00.000Z
 date: Oct 14, 2022
 time: 1:00 PM
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 
 The nf-core community will run a hackathon in the days leading up to the Nextflow Summit.

--- a/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
+++ b/src/content/events/oct-14-summit-wrap-up-and-farewell/index.md
@@ -11,5 +11,5 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---

--- a/src/content/events/oct-14-talks-2/index.md
+++ b/src/content/events/oct-14-talks-2/index.md
@@ -22,5 +22,5 @@ datetime: 2022-10-14T11:30:00.000Z
 date: Oct 14, 2022
 time: 11:30 AM
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---

--- a/src/content/events/oct-14-the-spinning-jenny-a-nextflow-pipeline-for-an-agent-based-model-of-the-first-industrial-revolution/index.md
+++ b/src/content/events/oct-14-the-spinning-jenny-a-nextflow-pipeline-for-an-agent-based-model-of-the-first-industrial-revolution/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">

--- a/src/content/events/oct-14-workflow-automation-using-the-aviti-benchtop-sequencing-system-and-nextflow-tower/index.md
+++ b/src/content/events/oct-14-workflow-automation-using-the-aviti-benchtop-sequencing-system-and-nextflow-tower/index.md
@@ -12,7 +12,7 @@ speakers:
 tags:
   - Community
 youtube: Watch on Youtube
-youtubeUrl: https://youtu.be/S9FDUEBSYCg
+youtubeUrl: https://youtu.be/SouMSDJBE1U
 ---
 <div className="mb-4">
   <small className="typo-small">


### PR DESCRIPTION
Since we dropped the number of streams (one per day instead of one per session), some of the YouTube links needed updating.

The playlist is still valid, and the first session of each day is still valid.