### PR TITLE
Add Slack icon to Slack buttons on poster page

### DIFF
--- a/src/components/PosterCard/index.jsx
+++ b/src/components/PosterCard/index.jsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import { GatsbyImage as Image, getImage } from "gatsby-plugin-image";
 import React from 'react';
 
-import { Link } from 'website-components';
+import { Button, Link, SlackIcon } from 'website-components';
 
 const PosterCard = ({ poster }) => (
   <div className="bg-black border border-gray-800 rounded-sm shadow-xl h-full group">

--- a/src/templates/poster.jsx
+++ b/src/templates/poster.jsx
@@ -7,12 +7,8 @@ import {
   AngleLeftIcon,
   Button,
   DownloadIcon,
-  GitHubIcon,
   Link,
-  LinkedInIcon,
-  LocationIcon,
-  TwitterIcon,
-  YoutubeRectangleIcon,
+  SlackIcon
 } from 'website-components';
 
 import CustomMDXProvider from '../components/CustomMDXProvider';
@@ -99,6 +95,7 @@ const PosterPage = ({ data }) => {
           </h1>
           <div className="flex mt-8 md:mt-auto">
             <Button to={"https://nextflow.slack.com/channels/summit-2022-poster-" + poster.poster_id} variant="accent" size="sm" arrow>
+              <SlackIcon className="h-4 w-4 inline-block mr-2" />
               Ask a question on Slack
             </Button>
           </div>


### PR DESCRIPTION
Minor, just adds the Slack icon to the button on the poster page:

<img width="395" alt="image" src="https://user-images.githubusercontent.com/465550/194386001-14d906a2-ee73-4229-9db2-f57c89c878d9.png">
