### PR TITLE
Add location tags to Boston hackathon social

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -191,6 +191,7 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId, createContentDig
       const fullEventPath = `${eventPath}${slug}/`;
       let location = 'barcelona';
       if (filePath.includes('boston')) location = 'boston';
+      if (node.frontmatter.location) location = node.frontmatter.location;
 
       const content = {
         type: parent.sourceInstanceName,

--- a/src/content/events-boston/nov-28-7/index.md
+++ b/src/content/events-boston/nov-28-7/index.md
@@ -12,5 +12,13 @@ speakers:
 tags:
 youtube:
 youtubeUrl:
+location: Cheeky Monkey Brewery
+locationUrl: https://maps.app.goo.gl/QuXuXK6h9ToNKBkg7
 ---
-Kick back and relax with fellow Hackathoners at [Cheeky Monkey Brewery](https://maps.app.goo.gl/QuXuXK6h9ToNKBkg7). This energetic brewpub offers its own beers and guest varieties, plus funky globally-inspired dishes. The venue has a game section with shuffleboard, pool, and other games where you can play with other Hackathoners!
+Kick back and relax with fellow Hackathoners at [Cheeky Monkey Brewery](https://www.bowlero.com/cheeky-monkey-brewing). This energetic brewpub offers its own beers and guest varieties, plus funky globally-inspired dishes. The venue has a game section with shuffleboard, pool, and other games where you can play with other Hackathoners!
+
+<div>
+  <Button to="https://maps.app.goo.gl/QuXuXK6h9ToNKBkg7" variant="secondary" size="md" arrow>
+    Directions to Cheeky Monkey Brewery
+  </Button>
+</div>


### PR DESCRIPTION
Tried to update the hackathon social to embed the location in the front matter, as just saying "Boston" is fairly unhelpful:

![CleanShot 2023-11-09 at 17 34 47@2x](https://github.com/nextflow-io/summit-website/assets/465550/65396259-1a05-4e6e-8d5e-88eb16342c92)


Pretty sure that this used to work, but I think that some of the logic with `location` has been overwritten with the Barcelona / Boston split. So maybe that needs renaming to `venue` and defaulting to `location` if not set or something?

The URL in the location works, and the other stuff added to the page is fine.