### PR TITLE
SessionCard - flag to hide speakers, for speaker deetail page

### DIFF
--- a/src/components/SessionCard/index.tsx
+++ b/src/components/SessionCard/index.tsx
@@ -12,6 +12,7 @@ type Props = {
   showDate?: boolean;
   hideTime?: boolean;
   showRoomName?: boolean;
+  hideSpeakers?: boolean;
 };
 
 const CardContainer = ({ children, session }) => {
@@ -33,6 +34,7 @@ const SessionCard: React.FC<Props> = ({
   hideTime,
   session,
   showRoomName,
+  hideSpeakers,
 }) => {
   return (
     <div className={clsx("w-full md:w-[400px]", className)}>
@@ -65,7 +67,7 @@ const SessionCard: React.FC<Props> = ({
             </span>
           )}
           <h2 className={styles.title}>{session.title}</h2>
-          {!!session.speakers.length && (
+          {!!session.speakers.length && !hideSpeakers && (
             <div
               className={clsx(
                 "text-sm text-nextflow-400 mt-3 font-light",

--- a/src/pages/2024/boston/speakers/[slug].astro
+++ b/src/pages/2024/boston/speakers/[slug].astro
@@ -56,10 +56,10 @@ const speaker = speakers.find((speaker) => speaker.slug === Astro.params.slug);
           {speaker.bio}
         </div>
         <h2 class="h2 mt-16 text-left mb-6">Sessions</h2>
-        <div class="flex flex-wrap -m-1">
+        <div class="flex flex-wrap -m-1 text-left">
           {
             speaker.sessions.map((session) => (
-              <SessionCard className="p-1" session={session} />
+              <SessionCard className="p-1" session={session} hideSpeakers={true} />
             ))
           }
         </div>


### PR DESCRIPTION
Avoid [this](https://summit.nextflow.io/2024/boston/speakers/geraldine-van-der-auwera/):

![CleanShot 2024-04-04 at 20 13 52@2x](https://github.com/nextflow-io/summit-website/assets/465550/bb334283-d562-483b-86f0-e3e0fc4f5f6a)

Also left align text, for consistency with other places in the site.

Fixed:

![CleanShot 2024-04-04 at 20 14 19@2x](https://github.com/nextflow-io/summit-website/assets/465550/bd695185-2f66-45fd-85ca-950c39caaef0)

@MythicalFish - note, this may be disabling some functionality that you had previously intended? I can't see speakers showing anywhere currently. This is just a quick fix but feel free to close / do a different better way / etc.

@netlify /2024/boston/speakers/geraldine-van-der-auwera