### PR TITLE
YouTube playlist on the Boston homepage

### DIFF
--- a/src/pages/2024/boston/index.astro
+++ b/src/pages/2024/boston/index.astro
@@ -29,7 +29,10 @@ import SEO from "@components/SEO";
     <KeyDates showTitle showImg />
   </section>
   <section class="container mb-8 lg:mb-20">
-    <YouTubeVideo id="JvjoZ9dPjq8" />
+    <h2 class="h1 mb-8">Watch the talks</h2>
+    <p class="mb-8">Catch up on the talks from Boston 2024 with the <a class="text-nextflow" href="https://youtube.com/playlist?list=PLPZ8WHdZGxmXuWK4X5yJyFDqNzc3GhVBz&si=1WeRs6z8gQd-JMg4">YouTube Playlist</a>
+      below, or browse the <a class="text-nextflow" href="/2024/boston/agenda">Agenda</a> to view individual talks.</p>
+    <YouTubeVideo id="mvhMnNl9lsQ" listId="PLPZ8WHdZGxmXuWK4X5yJyFDqNzc3GhVBz" />
   </section>
   <CTASection />
   <NextflowNumbers client:load className="py-20" />


### PR DESCRIPTION
Proposal: Instead of having the 2023 highlights reel on the Boston homepage, now show the 2024 Boston playlist as an embed.