### PR TITLE
Set of summit website updates

### DIFF
--- a/src/components/Marquee/CallForAbstracts/index.tsx
+++ b/src/components/Marquee/CallForAbstracts/index.tsx
@@ -12,7 +12,7 @@ const CallForAbstracts: React.FC<Props> = ({ className, href }) => {
     <Marquee
       speed={50}
       className={className}
-      href={href || "/2024/boston/call-for-abstracts/"}
+      href={href || "/2024/barcelona/call-for-abstracts/"}
     >
       <img className="ml-8" src={call_for_abstracts.src} />
       <img className="ml-8" src={call_for_abstracts.src} />

--- a/src/modules/EventSelector/Card.astro
+++ b/src/modules/EventSelector/Card.astro
@@ -1,5 +1,5 @@
 ---
-const { location } = Astro.props;
+const { location, btn_txt, btn_url, btn_cta } = Astro.props;
 import title_boston from "@images/title_boston-1a.svg";
 import title_barcelona from "@images/title_barcelona-1a.svg";
 import photo_boston from "./boston.jpg";
@@ -9,27 +9,40 @@ const title = location === "barcelona" ? title_barcelona : title_boston;
 const subtitle = location === "barcelona" ? "In person | Online" : "In person";
 const url = location === "barcelona" ? "/2024/barcelona" : "/2024/boston";
 import styles from "./styles.module.css";
+import Button from "@components/Button";
 ---
 
-<a
-  href={url}
-  class:list={[
-    "w-full sm:w-1/2 max-w-[384px] min-h-[200px] bg-brand-1000 my-2 mx-4 rounded-[16px] overflow-hidden text-center flex-auto",
-    styles.card,
-  ]}
->
-  <img src={photo.src} class="mb-8" />
-  <img src={title.src} class="inline-block" />
-  <div class="text-lg py-8 font-semibold">
-    <div class="uppercase">{subtitle}</div>
-    <div class="mt-3">
-      {
-        location === "boston" ? (
-          <div>May 21-24, 2024</div>
-        ) : (
-          <div class="">October 28 - November 1, 2024</div>
-        )
-      }
+<div class:list={[
+  "w-full sm:w-1/2 max-w-[384px] min-h-[200px] bg-brand-1000 my-2 mx-4 rounded-[16px] overflow-hidden text-center flex-auto",
+  styles.card,
+]}>
+  <a href={url}>
+    <img src={photo.src} class="mb-8" />
+    <img src={title.src} class="inline-block" />
+    <div class="text-lg py-8 font-semibold">
+      <div class="uppercase">{subtitle}</div>
+      <div class="mt-3">
+        {
+          location === "boston" ? (
+            <div>May 21-24, 2024</div>
+          ) : (
+            <div class="">October 28 - November 1, 2024</div>
+          )
+        }
     </div>
-  </div>
-</a>
+  </a>
+  {btn_txt && btn_url && (
+    <div class="mt-8">
+      <Button
+        href={btn_url}
+        cta={btn_cta}
+        arrow
+        wide
+        small
+        className="ml-auto"
+      >
+            {btn_txt}
+      </Button>
+    </div>
+  )}
+</div>

--- a/src/modules/EventSelector/index.astro
+++ b/src/modules/EventSelector/index.astro
@@ -17,8 +17,18 @@ import Card from "./Card.astro";
         Get ready for SUMMIT events in 2024, in Boston and Barcelona!
       </h1>
       <div class="flex flex-wrap justify-center -mx-4">
-        <Card location="boston" />
-        <Card location="barcelona" />
+        <Card
+          location="boston"
+          btn_txt="Watch the recordings"
+          btn_url="/2024/boston/agenda#05-23"
+          btn_cta={false}
+         />
+        <Card
+          location="barcelona"
+          btn_txt="Register now"
+          btn_url="/2024/barcelona/register"
+          btn_cta={true}
+         />
       </div>
     </div>
   </div>

--- a/src/modules/Preregister2025/index.jsx
+++ b/src/modules/Preregister2025/index.jsx
@@ -9,7 +9,7 @@ const Preregister2025 = () => {
     <div className="sm:px-10 py-8">
       <div className="text-center w-full sm:px-8">
         <h3 className="h2 text-white mb-2">
-          Interested in attending Nextflow Summit Boston in Spring 2025?
+          Interested in attending a Nextflow Summit in 2025?
         </h3>
         <div
           className="text-xl mb-6 font-[200]"
@@ -17,6 +17,12 @@ const Preregister2025 = () => {
         >
           We'll be back next year! Sign up for updates to be the first to know
           when tickets go on sale.
+        </div>
+        <div
+          className="text-lg mb-6 font-[200]"
+          style={{ color: "rgba(255,255,255,0.8)" }}
+        >
+          As in 2024, Boston will be held in Spring and Barcelona in Autumn.
         </div>
       </div>
       <div className="w-full">

--- a/src/pages/2024/boston/index.astro
+++ b/src/pages/2024/boston/index.astro
@@ -17,11 +17,11 @@ import SEO from "@components/SEO";
 <Layout namespace="2024/boston">
   <SEO slot="head" img={1} />
   <section class="pb-6 pt-16 md:pt-20">
-    <CallForAbstracts client:load className="pb-10 md:pb-20" />
     <div class="text-center container">
       <img src={title.src} class="mx-auto w-full max-w-[555px] px-10" />
       <div class="h00 mt-16 mb-8">MAY 21 - 24, 2024</div>
-      <Button href="/2024/boston/register" cta2 large>Register</Button>
+      <Button href="/2024/boston/agenda#05-23" cta large className="mr-3">Watch the recordings</Button>
+      <Button href="/preregister-2025" cta2 large>Pre-register 2025</Button>
     </div>
     <KeyInformation className="pt-16" linkPath="/2024/boston/agenda" />
   </section>

--- a/src/pages/2024/boston/register.astro
+++ b/src/pages/2024/boston/register.astro
@@ -1,5 +1,19 @@
 ---
 import Layout from "@layouts/Base.astro";
+import SEO from "@components/SEO";
+---
+
+<Layout namespace="2024" redirect="/preregister-2025/">
+  <SEO slot="head" />
+</Layout>
+
+
+<!--
+
+
+
+---
+import Layout from "@layouts/Base.astro";
 import { Image } from "astro:assets";
 import img from "@photos/audience-2b.jpg";
 import PastEvents from "@modules/PastEvents";
@@ -36,3 +50,5 @@ import Box from "@components/Box";
   <Contact className="py-8" />
   <SponsoredBy client:load />
 </Layout>
+
+-->

--- a/src/pages/2024/boston/travel.astro
+++ b/src/pages/2024/boston/travel.astro
@@ -14,7 +14,6 @@ import SEO from "@components/SEO";
 <Layout namespace="2024/boston">
   <SEO slot="head" title="Travel" img={1} />
   <section class="pb-6 pt-16 md:py-20">
-    <CallForAbstracts client:load className="pb-10 md:pb-16" />
     <div class="container island text-center">
       <h1 class="h00 mb-8">Join us in Boston</h1>
       <div class="blockquote">

--- a/src/pages/preregister-2025.astro
+++ b/src/pages/preregister-2025.astro
@@ -8,23 +8,17 @@ import Contact from "@modules/Contact";
 import { SponsoredBy } from "@components/Marquee";
 ---
 
-<Layout namespace="2024/boston">
+<Layout showNav={false}>
   <SEO slot="head" title="Pre-register 2025" img={1} />
   <section class="pb-6 pt-16 md:pt-20">
     <div class="container island text-center">
       <h2 class="h000 mb-2">
-        <span class="h1 text-nextflow">Attend</span><br />Nextflow Summit<br /> Boston
-        2025
+        <span class="h1 text-nextflow">Attend</span><br />Nextflow Summit<br /> 2025
       </h2>
-      <!-- <b class="font-bold text-fusion-600 text-xl">
-        Boston <span class="opacity-40">|</span> May 21-24
-      </b> -->
       <Box className="mt-12 mx-auto max-w-[764px]">
         <Preregister client:load />
       </Box>
     </div>
   </section>
-  <PastEvents title="Past events" client:visible />
   <Contact className="py-8" />
-  <SponsoredBy client:load />
 </Layout>


### PR DESCRIPTION
- Make pre-registration generic for both sites
- Update scrolling text banner to point to Barcelona call for abstracts, instead of Boston
- Remove scrolling banner from Boston website
- Update Boston homepage CTA button to pre-register and watch recordings, instead of register
- Add buttons to main homepage cards