### PR TITLE
Barcelona: Go live with rough agenda

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -42,17 +42,17 @@ const Calendar: React.FC<Props> = ({ location = "boston" }) => {
       <nav className={clsx(styles.nav, "container smaller")}>
         <a
           className={clsx({
-            [styles.active]: ["#05-21", "#05-22"].includes(activeHash),
+            [styles.active]: ["#05-21", "#05-22", "#10-28", "#10-29", "#10-30"].includes(activeHash),
           })}
-          href="#05-21"
+          href={location == "boston" ? "#05-21" : "#10-28"}
         >
           Hackathon + Training
         </a>
         <a
           className={clsx({
-            [styles.active]: ["#05-23", "#05-24"].includes(activeHash),
+            [styles.active]: ["#05-23", "#05-24", "#10-30", "#10-31", "#11-01"].includes(activeHash),
           })}
-          href="#05-23"
+          href={location == "boston" ? "#05-23" : "#10-30"}
         >
           Summit
         </a>
@@ -108,7 +108,7 @@ const Calendar: React.FC<Props> = ({ location = "boston" }) => {
                               key={i}
                               session={fullSession}
                               hideTime
-                              showVideoButton={true}
+                              // showVideoButton={true}
                               showRoomName={showRoomName}
                             />
                           );

--- a/src/data/sessionize.ts
+++ b/src/data/sessionize.ts
@@ -2,7 +2,7 @@ import type { Schedule } from "./schedule";
 
 const ids = {
   boston: "zaqv23uw",
-  barcelona: "t4f8qx5t",
+  barcelona: "hb4w1c5g",
 };
 
 const fetchSessionizeData = async (

--- a/src/data/sessions.ts
+++ b/src/data/sessions.ts
@@ -132,10 +132,10 @@ const getSessions = (location: Location = "boston"): Session[] => {
       // Add custom attributes
       .map((session) => ({
         ...session,
-        isKeynote: isKeynote(session),
-        isSponsor: isSponsor(session),
-        projectURL: getProjectURL(session),
-        coAuthors: getCoAuthors(session),
+        isKeynote: isKeynote(session, location),
+        isSponsor: isSponsor(session, location),
+        projectURL: getProjectURL(session, location),
+        coAuthors: getCoAuthors(session, location),
       }))
 
       // Associate room

--- a/src/layouts/Header/menuItems.ts
+++ b/src/layouts/Header/menuItems.ts
@@ -2,6 +2,10 @@ export default {
   barcelona: {
     main: [
       {
+        name: "Agenda",
+        url: "/agenda",
+      },
+      {
         name: "Travel",
         url: "/travel",
       },

--- a/src/modules/KeyInformation/data.ts
+++ b/src/modules/KeyInformation/data.ts
@@ -8,7 +8,7 @@ export default {
       title: "Training | May 21-22",
       subtitle: "2 days · 30 people · training",
       icon: parentheses,
-      link: "#05-21",
+      link: "/2024/boston/agenda#05-21",
       description:
         "An in-person foundational training to supercharge your pipeline development with Nextflow and nf-core. Running in parallel to the hackathon.",
     },
@@ -16,7 +16,7 @@ export default {
       title: "Hackathon | May 21-22",
       subtitle: "2 days · 100 people · hackathon",
       icon: computer,
-      link: "#05-22",
+      link: "/2024/boston/agenda#05-22",
       description:
         "An in-person hackathon to develop nf-core. Running in parallel to the training.",
     },
@@ -24,7 +24,7 @@ export default {
       title: "Summit | May 23-24",
       subtitle: "1.5 days · 200 people · talks, networking, and more",
       icon: news,
-      link: "#05-23",
+      link: "/2024/boston/agenda#05-23",
       description:
         "A showcase of the latest developments and innovations from the Nextflow world.",
     },
@@ -34,7 +34,7 @@ export default {
       title: "Training | Oct 28 - 30",
       subtitle: "2.5 days · 60 people · training",
       icon: parentheses,
-      link: "/training",
+      link: "/2024/barcelona/training",
       description:
         "An in-person foundational training for those who are completely new to Nextflow and nf-core. Running in parallel to the hackathon.",
     },
@@ -42,7 +42,7 @@ export default {
       title: "Hackathon | Oct 28 - 30",
       subtitle: "2.5 days · 180 people · hackathon",
       icon: computer,
-      link: "",
+      link: "/2024/barcelona/agenda#10-28",
       description:
       "An in-person hackathon open to anyone with some Nextflow knowledge. You’ll work on specific tasks in groups, collaborating on developing nf-core. Running in parallel to the training.",
     },
@@ -50,7 +50,7 @@ export default {
       title: "Summit | Oct 30 - Nov 1",
       subtitle: "2.5 days · 400 people · talks, networking, and more",
       icon: news,
-      link: "",
+      link: "/2024/barcelona/agenda#10-30",
       description:
         "A showcase of the latest developments and innovations from the Nextflow world. ",
     },

--- a/src/modules/KeyInformation/index.tsx
+++ b/src/modules/KeyInformation/index.tsx
@@ -6,24 +6,22 @@ import data from "./data";
 type Props = {
   className?: string;
   location?: "boston" | "barcelona";
-  linkPath?: string;
 };
 
 const KeyInformation: React.FC<Props> = ({
   className = "",
-  location = "boston",
-  linkPath = "",
+  location = "boston"
 }) => {
   return (
     <section className={clsx("container", className)}>
-      <div className="flex -m-2 lg:-m-4 flex flex-wrap">
+      <div className="flex -m-2 lg:-m-4 flex-wrap">
         {data[location].map((info) => (
           <div className="w-full md:w-1/3 p-2 lg:p-4">
             <InfoBox
               title={info.title}
               subtitle={info.subtitle}
               icon={info.icon}
-              link={!!info.link && `${linkPath}${info.link}`}
+              link={!!info.link && `${info.link}`}
             >
               {info.description}
             </InfoBox>

--- a/src/pages/2024/barcelona/agenda/index.astro
+++ b/src/pages/2024/barcelona/agenda/index.astro
@@ -25,25 +25,26 @@ import Accommodation from "@modules/Accommodation";
   </section>
   <section class="pt-10 pb-6">
     <div class="container">
-      <div id="05-21"></div>
-      <div id="05-22"></div>
-      <div id="05-23"></div>
-      <div id="05-24"></div>
+      <div id="10-28"></div>
+      <div id="10-29"></div>
+      <div id="10-30"></div>
+      <div id="10-31"></div>
+      <div id="11-01"></div>
       <h1 class="h00 mb-4 text-center pt-6 md:pt-10" id="timetable">Agenda</h1>
       <div class="mb-6 text-brand-100 text-center">
         Subscribe to calendar:
         <a
           class="text-nextflow"
-          href="https://sessionize.com/api/v2/5akke6uq/view/All">iCal</a
+          href="https://sessionize.com/api/v2/yyj6wctp/view/All">iCal</a
         > |
         <a
           class="text-nextflow"
-          href="https://calendar.google.com/calendar/render?cid=webcal://sessionize.com/api/v2/5akke6uq/view/All"
+          href="https://calendar.google.com/calendar/render?cid=webcal://sessionize.com/api/v2/yyj6wctp/view/All"
           >Google Calendar</a
         >
       </div>
     </div>
-    <Calendar client:load />
+    <Calendar client:load location="barcelona" />
   </section>
   <SponsoredBy client:load className="mt-12" />
   <Contact />

--- a/src/pages/2024/barcelona/index.astro
+++ b/src/pages/2024/barcelona/index.astro
@@ -30,7 +30,6 @@ import SEO from "@components/SEO";
     <KeyInformation
       className="pt-16"
       location="barcelona"
-      linkPath="/2024/barcelona"
     />
   </section>
   <section class="container relative z-10 mb-4 sm:mb-8 lg:mb-20">

--- a/src/pages/2024/boston/index.astro
+++ b/src/pages/2024/boston/index.astro
@@ -23,7 +23,7 @@ import SEO from "@components/SEO";
       <Button href="/2024/boston/agenda#05-23" cta large className="mr-3">Watch the recordings</Button>
       <Button href="/preregister-2025" cta2 large>Pre-register 2025</Button>
     </div>
-    <KeyInformation className="pt-16" linkPath="/2024/boston/agenda" />
+    <KeyInformation className="pt-16" />
   </section>
   <section class="container relative z-10 mb-4 sm:mb-8 lg:mb-20">
     <KeyDates showTitle showImg />


### PR DESCRIPTION
* Add 'Agenda' to top nav for Barcelona
* Link to agenda from KeyInfo boxes for hackathon + summit
* Render agenda from Sessionize for Barcelona
* Try not to break the Boston agenda in the process

@netlify /2024/barcelona/agenda/