### PR TITLE
Remove CFA scroll and link from navbar

### DIFF
--- a/src/layouts/Header/menuItems.ts
+++ b/src/layouts/Header/menuItems.ts
@@ -19,10 +19,12 @@ export default {
       },
     ],
     secondary: [
+      /*
       {
         name: "Call for Abstracts",
         url: "/call-for-abstracts",
       },
+      */
       {
         name: "Register",
         url: "/register",

--- a/src/pages/2024/barcelona/call-for-abstracts.astro
+++ b/src/pages/2024/barcelona/call-for-abstracts.astro
@@ -10,10 +10,10 @@ import SEO from "@components/SEO";
 <Layout namespace="2024/barcelona">
   <SEO slot="head" title="Call for abstracts" img={2} bcn />
   <section class="container island pt-10 md:pt-16">
-    <h2 class="h000 mb-2">The call for abstracts has been extended until June 21, 2024</h2>
+    <h2 class="h000 mb-2">The call for abstracts was closed on June 21, 2024</h2>
     <div class="blockquote mb-8">
       <p class="mt-8 mb-4">
-        Abstracts selected for short or long talks will receive <strong>free registration</strong> for the Nextflow Summit. Presenters will be notified in June.
+        Abstracts selected for short or long talks receive <strong>free registration</strong> for the Nextflow Summit.
       </p>
     </div>
     <Button

--- a/src/pages/2024/barcelona/index.astro
+++ b/src/pages/2024/barcelona/index.astro
@@ -17,11 +17,13 @@ import SEO from "@components/SEO";
 <Layout namespace="2024/barcelona">
   <SEO slot="head" img={2} bcn />
   <section class="pb-6 pt-16 md:pt-20">
+    <!--
     <CallForAbstracts
       client:load
       className="pb-10 md:pb-20"
       href="/2024/barcelona/call-for-abstracts"
     />
+    -->
     <div class="text-center container">
       <img src={title.src} class="mx-auto w-full max-w-[555px] px-10" />
       <div class="h00 mt-16 mb-8">OCT 28 - NOV 1, 2024</div>

--- a/src/pages/2024/barcelona/travel.astro
+++ b/src/pages/2024/barcelona/travel.astro
@@ -15,11 +15,6 @@ import { Code } from "astro:components";
 <Layout namespace="2024/barcelona">
   <SEO slot="head" title="Travel" img={2} bcn />
   <section class="pb-6 pt-16 md:py-20">
-    <CallForAbstracts
-      client:load
-      className="pb-10 md:pb-16"
-      href="/2024/barcelona/call-for-abstracts"
-    />
     <div class="container island text-center">
       <h1 class="h00 mb-8">Join us in Barcelona</h1>
       <div class="blockquote">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import SEO from "@components/SEO";
 
 <Layout showHeader={false}>
   <SEO slot="head" />
-  <CallForAbstracts client:load className="mt-20 opacity-75" />
+  <!--  <CallForAbstracts client:load className="mt-20 opacity-75" /> -->
   <EventSelector />
   <h2 class="h00 text-center mt-10 mb-16 relative z-10">
     Previous Nextflow Events


### PR DESCRIPTION
Can add back a replacement scroller later if we want to, but figured we should really take this down ASAP.