### PR TITLE
Posters listing page

### DIFF
--- a/src/components/SessionCard/index.tsx
+++ b/src/components/SessionCard/index.tsx
@@ -92,7 +92,7 @@ const SessionCard: React.FC<Props> = ({
                   <span className={styles.sponsor}>Sponsor</span>
                 )}
                 {!!session.posterPDF && (
-                  <span className={styles.sponsor}>View online</span>
+                  <span className={styles.sponsor}>View poster online</span>
                 )}
               </div>
               {showVideoButton && !!session.recordingUrl && (

--- a/src/components/SessionCard/index.tsx
+++ b/src/components/SessionCard/index.tsx
@@ -91,6 +91,9 @@ const SessionCard: React.FC<Props> = ({
                 {session.isSponsor && (
                   <span className={styles.sponsor}>Sponsor</span>
                 )}
+                {!!session.posterPDF && (
+                  <span className={styles.sponsor}>View online</span>
+                )}
               </div>
               {showVideoButton && !!session.recordingUrl && (
                 <Button

--- a/src/data/sessionUtils.ts
+++ b/src/data/sessionUtils.ts
@@ -32,6 +32,7 @@ export type Session = {
   room?: Room;
   liveUrl?: string;
   recordingUrl?: string;
+  posterPDF?: string;
   status: "Accepted" | "Declined" | "Nominated";
   isInformed: boolean;
   isConfirmed: boolean;
@@ -52,6 +53,7 @@ const questionIDs = {
     github: 76617,
     presentation: 76618,
     presentationPDF: 76619,
+    posterPDF: 83056,
     shareImage: 76621,
     shareImage2: 76622,
   },

--- a/src/layouts/Header/menuItems.ts
+++ b/src/layouts/Header/menuItems.ts
@@ -22,12 +22,12 @@ export default {
         url: "/speakers",
       },
       {
-        name: "Sponsors",
-        url: "/sponsors",
+        name: "Posters",
+        url: "/posters",
       },
       {
-        name: "Why attend",
-        url: "/why-attend",
+        name: "Sponsors",
+        url: "/sponsors",
       },
     ],
     secondary: [

--- a/src/pages/2024/barcelona/agenda/posters.astro
+++ b/src/pages/2024/barcelona/agenda/posters.astro
@@ -1,0 +1,37 @@
+---
+import Layout from "@layouts/Base.astro";
+import { SponsoredBy } from "@components/Marquee";
+import Contact from "@modules/Contact";
+import SEO from "@components/SEO";
+import SessionCard from "@components/SessionCard";
+import sessions from "@data/sessions";
+
+let posters = Array();
+{sessions['barcelona']?.map((session, i) => {
+  if(session.categories.type && session.categories.type[0] === 'Poster') {
+    posters.push(session);
+  }
+})}
+---
+
+<Layout namespace="2024/barcelona" altBG>
+  <SEO slot="head" title="Agenda" img={2} bcn />
+  <section class="pb-6 pt-16 md:pt-20">
+    <div class="container island pb-10 md:pb-20 text-center">
+      <h1 class="h00 mb-8">Posters</h1>
+      <div class="blockquote">
+        This premier event brings together leading experts, innovators, and
+        researchers to showcase the latest breakthroughs in workflow management.
+      </div>
+    </div>
+  </section>
+  <section class="pt-10 pb-6">
+    <div class="container">
+      <div class="flex flex-wrap -m-4">
+        {posters.map((poster) => <SessionCard session={poster} className="w-full md:w-1/2 p-4" hideTime={true}/> )}
+      </div>
+    </div>
+  </section>
+  <SponsoredBy client:load className="mt-12" location="barcelona" />
+  <Contact />
+</Layout>

--- a/src/pages/2024/barcelona/posters/[slug].astro
+++ b/src/pages/2024/barcelona/posters/[slug].astro
@@ -92,7 +92,7 @@ const speaker = speakers.barcelona?.find(
               {/* TODO: Hack to avoid downloads due to content-type header.
               If we can, remove the google docs viewer prefix at a later date.
                */}
-              <iframe src={`http://docs.google.com/gview?embedded=true&url=${encodeURIComponent(session.posterPDF)}`} class="w-full h-[800px] mt-10" />
+              <iframe src={`https://docs.google.com/gview?embedded=true&url=${encodeURIComponent(session.posterPDF)}`} class="w-full h-[800px] mt-10" />
             </>
           )
         }

--- a/src/pages/2024/barcelona/posters/[slug].astro
+++ b/src/pages/2024/barcelona/posters/[slug].astro
@@ -1,0 +1,116 @@
+---
+import Layout from "@layouts/Base.astro";
+import PersonCard from "@components/PersonCard";
+import ContentBox from "@components/ContentBox/index.astro";
+import Button from "@components/Button";
+import SEO from "@components/SEO";
+import { sessionPagesBarcelona as sessionPages } from "@data/sessions";
+import speakers from "@data/speakers";
+import { prettyDate, prettyTime } from "@utils/prettyDate";
+
+export function getStaticPaths() {
+  return sessionPages
+    .map((session) => {
+      if (!session?.slug) return null;
+      return {
+        params: { slug: session?.slug },
+        props: { session },
+      };
+    })
+    .filter((session) => session);
+}
+
+const { session } = Astro.props;
+const speakerCount = session.speakers.length;
+const isSingularSpeaker = speakerCount === 1;
+const speaker = speakers.barcelona?.find(
+  (speaker) => speaker.fullName === session.speakers[0]?.fullName,
+);
+---
+
+<Layout namespace="2024/barcelona" altBG>
+  <SEO
+    slot="head"
+    title={session.title}
+    dynamicImage={{
+      title: session.title,
+      subtitle: `${prettyDate(session.startsAt, false)} @ ${prettyTime(session.startsAt)} - ${prettyTime(session.endsAt)}`,
+      speaker: speaker?.slug,
+      location: "barcelona",
+    }}
+    bcn
+  />
+  <section class="pb-10 pt-16 md:py-20">
+    <div class="container smallest">
+      <ContentBox
+        backLink={{
+          label: "Back to posters",
+          href: "/2024/barcelona/posters",
+        }}
+      >
+        <div class="flex items-center mb-4">
+          {
+            !!session.isKeynote && (
+              <div class="bg-nextflow rounded-sm p-2 leading-none text-sm mr-4 text-brand">
+                Keynote
+              </div>
+            )
+          }
+          <div class="text-nextflow">
+            {prettyDate(session.startsAt, false)}
+            {
+              !!session.endsAt && (
+                <>
+                  <span class="opacity-50 -ml-1">, </span>
+                  {`${prettyTime(session.startsAt)} - ${prettyTime(session.endsAt)}`}
+                </>
+              )
+            }
+          </div>
+        </div>
+        <h1 class="text-3xl md:text-4xl font-bold mb-8 font-display">
+          {session.title}
+        </h1>
+        <div
+          class="text-left text-brand-300 font-light text-sm sm:text-base whitespace-pre-line"
+        >
+          {session.description}
+        </div>
+        {
+          !!session.projectURL && (
+            <Button cta href={session.projectURL} className="mt-6">
+              View project
+            </Button>
+          )
+        }
+        {
+          !!speakerCount && (
+            <>
+              <h2 class="h2 mt-16 text-left mb-6">
+                {isSingularSpeaker ? "Speaker" : "Speakers"}
+              </h2>
+              <div class="flex flex-wrap -m-2">
+                {session.speakers.map((speaker, i) => (
+                  <PersonCard
+                    className="p-2 w-full"
+                    person={speaker}
+                    location="barcelona"
+                    smaller
+                  />
+                ))}
+              </div>
+            </>
+          )
+        }
+        {
+          !!session.coAuthors && (
+            <>
+              <h3 class="h4 mt-10 text-left mb-2">Co-authors</h3>
+              <div class="font-light text-brand-200">{session.coAuthors}</div>
+            </>
+          )
+        }
+      </ContentBox>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/2024/barcelona/posters/[slug].astro
+++ b/src/pages/2024/barcelona/posters/[slug].astro
@@ -92,7 +92,7 @@ const speaker = speakers.barcelona?.find(
               {/* TODO: Hack to avoid downloads due to content-type header.
               If we can, remove the google docs viewer prefix at a later date.
                */}
-              <iframe src={"http://docs.google.com/gview?embedded=true&url="+session.posterPDF} class="w-full h-[800px] mt-10" />
+              <iframe src={`http://docs.google.com/gview?embedded=true&url=${encodeURIComponent(session.posterPDF)}`} class="w-full h-[800px] mt-10" />
             </>
           )
         }

--- a/src/pages/2024/barcelona/posters/[slug].astro
+++ b/src/pages/2024/barcelona/posters/[slug].astro
@@ -78,9 +78,22 @@ const speaker = speakers.barcelona?.find(
         </div>
         {
           !!session.projectURL && (
-            <Button cta href={session.projectURL} className="mt-6">
+            <Button cta href={session.projectURL} className="mt-6 mr-3">
               View project
             </Button>
+          )
+        }
+        {
+          !!session.posterPDF && (
+            <>
+              <Button cta href={session.posterPDF} className="mt-6">
+                Download poster
+              </Button>
+              {/* TODO: Hack to avoid downloads due to content-type header.
+              If we can, remove the google docs viewer prefix at a later date.
+               */}
+              <iframe src={"http://docs.google.com/gview?embedded=true&url="+session.posterPDF} class="w-full h-[800px] mt-10" />
+            </>
           )
         }
         {

--- a/src/pages/2024/barcelona/posters/index.astro
+++ b/src/pages/2024/barcelona/posters/index.astro
@@ -8,7 +8,7 @@ import sessions from "@data/sessions";
 
 let posters = Array();
 {sessions['barcelona']?.map((session, i) => {
-  if(session.categories.type && session.categories.type[0] === 'Poster') {
+  if(session.categories.outcome && session.categories.outcome[0] === 'Poster') {
     session.url = session.url.replace('/agenda/', '/posters/');
     posters.push(session);
   }
@@ -21,15 +21,15 @@ let posters = Array();
     <div class="container island pb-10 md:pb-20 text-center">
       <h1 class="h00 mb-8">Posters</h1>
       <div class="blockquote">
-        Explore posters from the community and learn about their work.
-        Posters are exhibited in person and can be viewed online if the speaker chooses.
+        Explore posters from the community and learn about their work.<br class="hidden sm:inline">
+        The Poster session is Thursday Oct 31,  3.30 - 4.30<sup>PM</sup>.
       </div>
     </div>
   </section>
   <section class="pb-6">
     <div class="container">
       <div class="flex flex-wrap -m-4">
-        {posters.map((poster) => <SessionCard session={poster} className="w-full md:w-1/2 p-4" hideTime={true}/> )}
+        {posters.map((poster) => <SessionCard session={poster} className="w-full md:w-1/2 p-4" minimal={true} /> )}
       </div>
     </div>
   </section>

--- a/src/pages/2024/barcelona/posters/index.astro
+++ b/src/pages/2024/barcelona/posters/index.astro
@@ -9,6 +9,7 @@ import sessions from "@data/sessions";
 let posters = Array();
 {sessions['barcelona']?.map((session, i) => {
   if(session.categories.type && session.categories.type[0] === 'Poster') {
+    session.url = session.url.replace('/agenda/', '/posters/');
     posters.push(session);
   }
 })}

--- a/src/pages/2024/barcelona/posters/index.astro
+++ b/src/pages/2024/barcelona/posters/index.astro
@@ -21,12 +21,12 @@ let posters = Array();
     <div class="container island pb-10 md:pb-20 text-center">
       <h1 class="h00 mb-8">Posters</h1>
       <div class="blockquote">
-        This premier event brings together leading experts, innovators, and
-        researchers to showcase the latest breakthroughs in workflow management.
+        Explore posters from the community and learn about their work.
+        Posters are exhibited in person and can be viewed online if the speaker chooses.
       </div>
     </div>
   </section>
-  <section class="pt-10 pb-6">
+  <section class="pb-6">
     <div class="container">
       <div class="flex flex-wrap -m-4">
         {posters.map((poster) => <SessionCard session={poster} className="w-full md:w-1/2 p-4" hideTime={true}/> )}


### PR DESCRIPTION
New page listing all posters.

Deployment preview direct link: https://deploy-preview-256--nextflow-summit-2024.netlify.app/2024/barcelona/agenda/posters/

Todo:

- [x] If a poster PDF is updated, show it embedded on the abstract detail page, plus show icon on poster listing oage
- [x] Sort posters (alphabetical by author name?
- [x] Figure out where to link to this page from

@netlify /2024/barcelona/posters/