### PR TITLE
Remove KeyInformation boxes from agenda

### DIFF
--- a/src/pages/2024/barcelona/agenda/index.astro
+++ b/src/pages/2024/barcelona/agenda/index.astro
@@ -15,23 +15,17 @@ import { Icon } from "astro-icon/components";
 <Layout namespace="2024/barcelona" altBG>
   <SEO slot="head" title="Agenda" img={2} bcn />
   <section class="pb-6 pt-16 md:pt-20">
-    <div class="container island pb-10 md:pb-20 text-center">
-      <h1 class="h00 mb-8">Join us in Barcelona</h1>
+    <div class="container island text-center">
+      <h1 class="h00 mb-8" id="timetable">Join us in Barcelona</h1>
       <div class="blockquote">
         This premier event brings together leading experts, innovators, and
         researchers to showcase the latest breakthroughs in workflow management.
       </div>
-    </div>
-    <KeyInformation className="pb-8 md:pb-0" location="barcelona" />
-  </section>
-  <section class="pt-10 pb-6">
-    <div class="container">
       <div id="10-28"></div>
       <div id="10-29"></div>
       <div id="10-30"></div>
       <div id="10-31"></div>
       <div id="11-01"></div>
-      <h1 class="h00 mb-4 text-center pt-6 md:pt-10" id="timetable">Agenda</h1>
       <div class="mb-3 text-brand-100 text-center">
         Subscribe to calendar:
         <a

--- a/src/pages/2024/barcelona/agenda/index.astro
+++ b/src/pages/2024/barcelona/agenda/index.astro
@@ -26,7 +26,7 @@ import { Icon } from "astro-icon/components";
       <div id="10-30"></div>
       <div id="10-31"></div>
       <div id="11-01"></div>
-      <div class="mb-3 text-brand-100 text-center">
+      <div class="mt-6 mb-3 text-brand-100 text-center">
         Subscribe to calendar:
         <a
           class="text-nextflow"

--- a/src/pages/2024/boston/agenda/index.astro
+++ b/src/pages/2024/boston/agenda/index.astro
@@ -20,17 +20,11 @@ import Accommodation from "@modules/Accommodation";
         This premier event brings together leading experts, innovators, and
         researchers to showcase the latest breakthroughs in workflow management.
       </div>
-    </div>
-    <KeyInformation className="pb-8 md:pb-0" />
-  </section>
-  <section class="pt-10 pb-6">
-    <div class="container">
       <div id="05-21"></div>
       <div id="05-22"></div>
       <div id="05-23"></div>
       <div id="05-24"></div>
-      <h1 class="h00 mb-4 text-center pt-6 md:pt-10" id="timetable">Agenda</h1>
-      <div class="mb-6 text-brand-100 text-center">
+      <div class="mt-6 text-brand-100 text-center">
         Subscribe to calendar:
         <a
           class="text-nextflow"


### PR DESCRIPTION
These boxes are duplicated from the homepage, and push the agenda down the page. 2/3 link to other webpages on the summit site and folks were getting confused as to where to find the agenda:

![CleanShot 2024-09-12 at 13 18 50@2x](https://github.com/user-attachments/assets/86fb12d5-f415-44cb-bee2-499250cf3151)

This PR removes them (they're on the homepage still), Agenda becomes much more visible:

![CleanShot 2024-09-12 at 13 18 43@2x](https://github.com/user-attachments/assets/ab449994-a640-4d2f-93a5-9fc1d0bc5010)

@netlify /2024/barcelona/agenda#10-28