### PR TITLE
Barcelona Live Stream - Day 3

### DIFF
--- a/src/pages/2024/barcelona/stream.astro
+++ b/src/pages/2024/barcelona/stream.astro
@@ -80,7 +80,7 @@ import SEO from "@components/SEO";
           </div>
           <div class="w-full md:w-1/2 p-2 min-h-[300px] relative">
             <div class="h-full w-full relative rounded-lg overflow-hidden">
-              <YouTubeVideo id="LkQj1fMZpHE" />
+              <YouTubeVideo id="Egrtue_IjRg" />
             </div>
           </div>
 


### PR DESCRIPTION
@mavi-sqr I realised that the live stream page has a single video embedded rather than the playlist. I just pushed an update to embed day 2, this PR is to merge tomorrow morning for day 3.

Is it possible to embed a playlist instead of a single video? That would be good to have after the event finishes especially.