### PR TITLE
Redirect: 2025 virtual registration page

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,6 @@
+# 2025 - Goldcast event registration
+/2025/virtual/register/   https://seqera.registration.goldcast.io/events/dc611bf3-ddc4-4a20-9f2f-1a9e941cc68c    200!
+
 # 2025 - Update provisional talk title URLs
 /2025/boston/agenda/product-keynote   /2025/boston/agenda/from-pipelines-to-platform
 /2025/boston/agenda/doing-ai-right    /2025/boston/agenda/responsible-ai-in-genomics


### PR DESCRIPTION
New redirect for the virtual summit registration page.

Should allow us to have a nice URL for registration.