### PR TITLE
feat: add draft mode infrastructure for Sanity preview

### DIFF
--- a/src/data/draftClient.ts
+++ b/src/data/draftClient.ts
@@ -1,0 +1,11 @@
+import { sanityClient } from 'sanity:client'
+
+// Returns a client configured to fetch draft content.
+// Use in fetchers when Astro.locals.draftMode is true.
+export function getDraftClient() {
+  return sanityClient.withConfig({
+    useCdn: false,
+    token: import.meta.env.SANITY_API_READ_TOKEN,
+    perspective: 'previewDrafts',
+  })
+}

--- a/src/data/draftClient.ts
+++ b/src/data/draftClient.ts
@@ -5,7 +5,7 @@ import { sanityClient } from 'sanity:client'
 export function getDraftClient() {
   return sanityClient.withConfig({
     useCdn: false,
-    token: import.meta.env.SANITY_API_READ_TOKEN,
+    token: import.meta.env.SANITY_READ_TOKEN,
     perspective: 'previewDrafts',
   })
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,7 +9,7 @@ declare namespace App {
 }
 
 interface ImportMetaEnv {
-  readonly SANITY_API_READ_TOKEN: string;
+  readonly SANITY_READ_TOKEN: string;
 }
 
 interface Window {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,17 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
 /// <reference types="@sanity/astro/module" />
+
+declare namespace App {
+  interface Locals {
+    draftMode: boolean;
+  }
+}
+
+interface ImportMetaEnv {
+  readonly SANITY_API_READ_TOKEN: string;
+}
+
 interface Window {
   gtag: (command: string, ...args: any[]) => void;
   dataLayer: any[];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,9 @@
+import { defineMiddleware } from 'astro:middleware'
+
+const DRAFT_MODE_COOKIE = 'sanity-draft-mode'
+
+export const onRequest = defineMiddleware((context, next) => {
+  const draftMode = context.cookies.get(DRAFT_MODE_COOKIE)?.value === 'true'
+  context.locals.draftMode = draftMode
+  return next()
+})

--- a/src/pages/api/draft-mode/disable.ts
+++ b/src/pages/api/draft-mode/disable.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro'
+
+export const prerender = false
+
+export const GET: APIRoute = ({ cookies, redirect }) => {
+  cookies.delete('sanity-draft-mode', { path: '/' })
+  return redirect('/')
+}

--- a/src/pages/api/draft-mode/enable.ts
+++ b/src/pages/api/draft-mode/enable.ts
@@ -1,0 +1,34 @@
+import type { APIRoute } from 'astro'
+import { validatePreviewUrl } from '@sanity/preview-url-secret'
+import { sanityClient } from 'sanity:client'
+
+export const prerender = false
+
+export const GET: APIRoute = async ({ request, cookies, redirect }) => {
+  const token = import.meta.env.SANITY_API_READ_TOKEN
+
+  if (!token) {
+    return new Response('SANITY_API_READ_TOKEN is not set', { status: 500 })
+  }
+
+  const clientWithToken = sanityClient.withConfig({
+    useCdn: false,
+    token,
+  })
+
+  const { isValid, redirectTo = '/' } = await validatePreviewUrl(clientWithToken, request.url)
+
+  if (!isValid) {
+    return new Response('Invalid preview secret', { status: 401 })
+  }
+
+  cookies.set('sanity-draft-mode', 'true', {
+    httpOnly: true,
+    sameSite: 'none',
+    secure: true,
+    path: '/',
+    maxAge: 60 * 60, // 1 hour
+  })
+
+  return redirect(redirectTo)
+}

--- a/src/pages/api/draft-mode/enable.ts
+++ b/src/pages/api/draft-mode/enable.ts
@@ -5,10 +5,10 @@ import { sanityClient } from 'sanity:client'
 export const prerender = false
 
 export const GET: APIRoute = async ({ request, cookies, redirect }) => {
-  const token = import.meta.env.SANITY_API_READ_TOKEN
+  const token = import.meta.env.SANITY_READ_TOKEN
 
   if (!token) {
-    return new Response('SANITY_API_READ_TOKEN is not set', { status: 500 })
+    return new Response('SANITY_READ_TOKEN is not set', { status: 500 })
   }
 
   const clientWithToken = sanityClient.withConfig({


### PR DESCRIPTION
- middleware.ts: reads sanity-draft-mode cookie, exposes Astro.locals.draftMode
- api/draft-mode/enable: validates Sanity preview secret, sets cookie, redirects
- api/draft-mode/disable: clears cookie and redirects home
- data/draftClient.ts: helper that returns a Sanity client with perspective previewDrafts
- env.d.ts: types for Locals.draftMode and SANITY_API_READ_TOKEN

Requires SANITY_API_READ_TOKEN (viewer token from sanity.io/manage) in env vars.