### PR TITLE
Move the 'catch all' redirect to the end of the file

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,8 +1,4 @@
 
-# SSR catch-all — routes unmatched requests to the Netlify SSR function.
-# Note: @astrojs/netlify v5 renamed the function from `entry` to `ssr`.
-/* /.netlify/functions/ssr 404
-
 # 2025 - archive site proxy
 /2025/*       https://nextflow-summit-2025.netlify.app/2025/:splat    200!
 
@@ -14,3 +10,7 @@
 
 # 2022 - archive site proxy
 /2022/*       https://nextflow-summit-2022.netlify.app/2022/:splat    200!
+
+# SSR catch-all — routes unmatched requests to the Netlify SSR function.
+# Note: @astrojs/netlify v5 renamed the function from `entry` to `ssr`.
+/* /.netlify/functions/ssr 404


### PR DESCRIPTION
https://github.com/nextflow-io/summit-website/pull/344 changed the `/*` catch all redirect rule, but accidentally moved it to the top of the file.

This file is processed in order, so this means that it now ran first and the other historical site redirect rules were never reached. This broke all the old site redirects.

This PR moves it back to the end of the file.