### PR TITLE
Changing data structure

### DIFF
--- a/src/data/menus.ts
+++ b/src/data/menus.ts
@@ -10,12 +10,14 @@ export interface Link {
 export interface MenuItem {
   linkTitle: string;
   link: Link;
+  /** Optional sub-links. If present, this tab shows a secondary bar across its section. */
+  secondaryNav?: MenuItem[];
 }
 
 export interface Button {
   buttonText?: string;
   buttonLink?: string;
-  buttonUrl?: string;
+  buttonUrl?: Link;
   externalLink?: boolean;
 }
 
@@ -51,14 +53,74 @@ export interface FooterGroup {
 export interface MenusData {
   _id: string;
   _type: string;
+  /** Single ordered list of header tabs. A tab with `secondaryNav` shows a sub-bar across its section. */
   headerMenu?: MenuItem[];
   headerBtn?: Button;
-  secondaryPath?: string;
-  secondaryMenu?: MenuItem[];
   mobileMenu?: MobileMenuItem[];
   footerMenu?: FooterGroup[];
   mobileBtn?: Button;
   mobileBtn2?: Button;
+  // --- transition fallback only (pre-unified model); safe to drop once data is migrated ---
+  /** @deprecated superseded by `headerMenu[].secondaryNav`. */
+  secondaryPath?: string;
+  /** @deprecated superseded by `headerMenu[].secondaryNav`. */
+  secondaryMenu?: MenuItem[];
+}
+
+/**
+ * The "section" a header tab owns, used to decide where its secondary bar shows.
+ * It is the first two URL segments of the tab's own internal link
+ * (e.g. "2026/barcelona/overview" -> "2026/barcelona"). External or empty links have no section.
+ */
+function sectionOf(link?: Link): string | null {
+  if (!link || link.isExternal) return null;
+  const internal = link.internalLink;
+  if (!internal) return null;
+  const segments = internal.replace(/^\/+/, '').split('/').filter(Boolean);
+  if (segments.length === 0) return null;
+  return segments.slice(0, 2).join('/');
+}
+
+/**
+ * Builds the primary header navigation: simply the ordered `headerMenu` list.
+ * Order is fully controlled by the editor (drag-to-reorder in the CMS).
+ */
+export function buildPrimaryNav(menus: MenusData | undefined): MenuItem[] {
+  return menus?.headerMenu ?? [];
+}
+
+/**
+ * Resolves which secondary (sub) navigation to show for the current path.
+ *
+ * A tab's secondary bar shows when the visited URL falls within that tab's section
+ * (derived from the tab's own link). The most specific (longest) matching section wins,
+ * so editions never collide. Tabs without sub-links (e.g. FAQ) show no secondary bar.
+ */
+export function resolveSecondaryMenu(
+  menus: MenusData | undefined,
+  pathname: string
+): MenuItem[] | null {
+  if (!menus || !pathname) return null;
+
+  const match = (menus.headerMenu ?? [])
+    .filter((item) => item?.secondaryNav && item.secondaryNav.length > 0)
+    .map((item) => ({ section: sectionOf(item.link), nav: item.secondaryNav! }))
+    .filter((c) => c.section && pathname.includes(c.section))
+    .sort((a, b) => (b.section!.length ?? 0) - (a.section!.length ?? 0))[0];
+
+  if (match?.nav) return match.nav;
+
+  // transition fallback: legacy single secondary nav (removable once CMS data is migrated)
+  if (
+    menus.secondaryPath &&
+    pathname.includes(menus.secondaryPath) &&
+    menus.secondaryMenu &&
+    menus.secondaryMenu.length > 0
+  ) {
+    return menus.secondaryMenu;
+  }
+
+  return null;
 }
 
 export async function fetchMenus(): Promise<MenusData> {
@@ -71,6 +133,14 @@ export async function fetchMenus(): Promise<MenusData> {
         isExternal,
         internalLink,
         externalUrl
+      },
+      secondaryNav[]{
+        linkTitle,
+        link {
+          isExternal,
+          internalLink,
+          externalUrl
+        }
       }
     },
     headerBtn {

--- a/src/layouts/Header/index.astro
+++ b/src/layouts/Header/index.astro
@@ -9,7 +9,7 @@ import SecondaryMenu from './SecondaryMenu';
 import Logo from './Logo';
 import Button from '@components/Button';
 
-import { fetchMenus } from '@data/menus';
+import { fetchMenus, resolveSecondaryMenu, buildPrimaryNav } from '@data/menus';
 import { formatLink } from '@utils/linkFormatter';
 
 const menus = await fetchMenus();
@@ -17,8 +17,8 @@ const menus = await fetchMenus();
 let showNav = true;
 if (typeof Astro.props.showNav !== 'undefined') showNav = Astro.props.showNav;
 
-const shouldShowSecondaryMenu =
-  menus?.secondaryPath && pathname.includes(menus.secondaryPath);
+const primaryMenuItems = buildPrimaryNav(menus);
+const secondaryMenuItems = resolveSecondaryMenu(menus, pathname);
 ---
 
 <header
@@ -40,7 +40,7 @@ const shouldShowSecondaryMenu =
             </div>
             <a class="absolute top-0 left-0 w-full h-full z-10" href="/" aria-label="Navigate to home"></a>
           </div>
-          <Menu menuItems={menus?.headerMenu} pathname={pathname} />
+          <Menu menuItems={primaryMenuItems} pathname={pathname} />
           <div>
             {
               menus?.headerBtn && (
@@ -63,9 +63,8 @@ const shouldShowSecondaryMenu =
     </div>
 
     {
-      shouldShowSecondaryMenu &&
-        menus?.secondaryMenu &&
-        menus.secondaryMenu.length > 0 && (
+      secondaryMenuItems &&
+        secondaryMenuItems.length > 0 && (
           <div
             class={`${styles.navigation} js-secondary-nav transition-all duration-300`}
           >
@@ -73,7 +72,7 @@ const shouldShowSecondaryMenu =
               <SecondaryMenu
                 pathname={pathname}
                 namespace={namespace}
-                menuItems={menus.secondaryMenu}
+                menuItems={secondaryMenuItems}
                 client:load
               />
             </div>


### PR DESCRIPTION

Fix secondary nav for Boston & Virtual
The header sub-nav only worked for Barcelona. Now it's a single ordered menu list where each tab can have its own secondary bar — so every edition works.